### PR TITLE
Add endpoints for creating/removing/viewing user connections

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ import express from 'express';
 import './config.js';
 import sessionRoute from './route/session.js';
 import userRoute from './route/user.js';
+import connectionRoute from './route/connections.js';
 
 // Set up Express.js routing
 // TODO: some CORS and HTTPS configuration may be necessary here
@@ -11,6 +12,7 @@ const server = express();
 server.use(express.json());
 server.use('/session', sessionRoute);
 server.use('/user', userRoute);
+server.use('/connections', connectionRoute);
 
 server.listen(process.env.PORT, function(err, _data) {
     if (err) {

--- a/backend/src/controller/connections.js
+++ b/backend/src/controller/connections.js
@@ -1,0 +1,113 @@
+import * as connectionsModel from '../model/connections.js';
+
+export async function createConnection(req, res) {
+    // `from` is essentially useless here but is included for
+    // consistency with other endpoints
+    let { from, to } = req.query;
+
+    if (from && from !== req.body.uid) {
+        return res.status(403).json({
+            error: 'Cannot add connections for other users'
+        });
+    } else if (!from) {
+        // Not RESTful, but more intuitive
+        from = req.body.uid;
+    }
+
+    if (!to || to === from) {
+        return res.status(400).json({
+            error: 'Must provide connection target'
+        });
+    }
+
+    const connLoc = `/connections?from=${from}&to=${to}`;
+
+    // First, check if we're already connected
+    const connection = await connectionsModel.getOneConnection(from, to);
+
+    if (connection !== null) {
+        if (connection.status == connectionsModel.CONNECTION_STATUS.PENDING) {
+            return res.status(409).json({
+                error: 'Pending request already exists',
+                href: connLoc
+            });
+        }
+        if (connection.status == connectionsModel.CONNECTION_STATUS.ACCEPTED) {
+            return res.status(409).json({
+                error: 'Already connected',
+                href: connLoc
+            });
+        }
+    }
+
+    // We also need to check if they have requested to connect with us
+    // Note that connections are mutual so this can only be pending
+    const request = await connectionsModel.getOneConnection(to, from);
+    if (request !== null) {
+        await connectionsModel.acceptPendingConnection(from, to);
+    } else {
+        await connectionsModel.addPendingConnection(from, to);
+    }
+
+    return res.status(201).location(connLoc).send();
+}
+
+export async function viewConnections(req, res) {
+    const { from, to, pending } = req.query;
+
+    if (!from && !to) {
+        return res.status(400).json({
+            error: 'Must provide requester or requestee of connection'
+        });
+    } if (from !== req.body.uid && to !== req.body.uid) {
+        return res.status(403).json({
+            error: 'Cannot see connections from other users'
+        });
+    }
+
+    let status = connectionsModel.CONNECTION_STATUS.PENDING;
+    if (!pending) {
+        status = connectionsModel.CONNECTION_STATUS.ACCEPTED;
+    }
+
+    const [err, connections] = await connectionsModel.getConnections(
+        from, to, status
+    );
+
+    if (err !== null) {
+        return res.status(err.code).json({ error: err.message });
+    } else {
+        return res.status(200).json({ connections: connections });
+    }
+}
+
+export async function deleteConnection(req, res) {
+    let { from, to } = req.query;
+    const uid = req.body.uid;
+
+    if (!from && !to) {
+        return res.status(400).json({
+            error: 'Must provide requester or requestee of connection'
+        });
+    } else if (!from) {
+        // If only `to`, delete connection from us
+        from = uid;
+    } else if (!to) {
+        // If only `from`, delete connection from someone else to us
+        to = uid;
+    } else if (from !== uid && to !== uid) {
+        // If they both exist, at least one must be us
+        return res.status(403).json({
+            error: 'Cannot delete connections for other users'
+        });
+    }
+
+    if (from === uid && to === uid) {
+        return res.status(400).json({
+            error: 'Cannot delete connection to self'
+        });
+    }
+
+    await connectionsModel.deleteConnection(from, to);
+    return res.status(204).send();
+}

--- a/backend/src/model/connections.js
+++ b/backend/src/model/connections.js
@@ -1,0 +1,80 @@
+import pool from '../database.js';
+import { ResError } from '../error.js';
+
+export const CONNECTION_STATUS = {
+    PENDING: 0,
+    ACCEPTED: 1
+}
+
+export async function getConnections(from, to, status) {
+    let choice, args;
+    if (from && to) {
+        choice = 'uid_from = ? AND uid_to = ?';
+        args = [from, to];
+    } else if (from) {
+        choice = 'uid_from = ?';
+        args = [from];
+    } else if (to) {
+        choice = 'uid_to = ?';
+        args = [to];
+    } else {
+        return [
+            new ResError(400, 'Either to or from must be non-null'),
+            null
+        ];
+    }
+
+    if (status != undefined) {
+        choice += ' AND status = ?';
+        args.push(status);
+    }
+
+    const [connections] = await pool.query(`
+        SELECT uid_to AS uidTo, uid_from AS uidFrom, status
+        FROM connections WHERE ${choice}`,
+        args
+    );
+    return [null, connections];
+}
+
+export async function getOneConnection(from, to, status) {
+    const [_, connections] = await getConnections(from, to, status);
+    return (!connections.length) ? null : connections[0];
+}
+
+async function addConnection(from, to, status) {
+    await pool.query(
+        'INSERT INTO connections (uid_to, uid_from, status) VALUES (?, ?, ?)',
+        [to, from, status]
+    );
+
+    return null;
+}
+
+export async function addPendingConnection(from, to) {
+    return await addConnection(from, to, CONNECTION_STATUS.PENDING);
+}
+
+export async function acceptPendingConnection(from, to) {
+    const acceptQuery = `
+    UPDATE connections
+    SET status = ?
+    WHERE uid_to = ? AND uid_from = ?`;
+
+    // Upgrade pending to accepted (original `from` is current `to`)
+    await pool.query(acceptQuery, [CONNECTION_STATUS.ACCEPTED, from, to]);
+
+    // Then, create mutual connection the other direction
+    await addConnection(from, to, CONNECTION_STATUS.ACCEPTED);
+    return null;
+}
+
+export async function deleteConnection(from, to) {
+    const delQuery = `
+    DELETE FROM connections
+    WHERE (uid_to = ? AND uid_from = ?) OR (uid_from = ? AND uid_to = ?)`;
+
+    // Connections are mutual, so delete both
+    await pool.query(delQuery, [from, to, from, to]);
+    return null;
+}

--- a/backend/src/route/connections.js
+++ b/backend/src/route/connections.js
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+
+import * as connectionController from '../controller/connections.js';
+import { authorizeUserMiddleware } from '../middleware/auth.js';
+
+const connectionsRoute = Router();
+
+/*
+ * Create new pending or accept existing (POST connections?to=...)
+ *
+ * Get pending (GET connections?from=...&to=...&pending=1)
+ * Get accepted (GET connections?from=...&to=...) [implicit: &pending=0]
+ *
+ * Delete connection/reject pending (DELETE connections?from=...&to=...)
+ */
+
+connectionsRoute.post('/',
+    authorizeUserMiddleware,
+    connectionController.createConnection
+);
+
+connectionsRoute.get('/',
+    authorizeUserMiddleware,
+    connectionController.viewConnections
+);
+
+connectionsRoute.delete('/',
+    authorizeUserMiddleware,
+    connectionController.deleteConnection
+);
+
+export default connectionsRoute;


### PR DESCRIPTION
Added new set of endpoints, all located at /connections, to:
 - create a connection (POST)
 - view a connection (GET)
 - destroy/decline connections (DELETE)

The behavior can be changed with query parameters indicating the source ('from=...') and the sink ('to=...'). When viewing, one can indicate whether they want pending connection with the query parameter 'pending'.